### PR TITLE
MISC - fhir, profesionales con matriculas no vigentes

### DIFF
--- a/src/services/practitioner/practitioner.service.ts
+++ b/src/services/practitioner/practitioner.service.ts
@@ -53,7 +53,7 @@ let buildAndesSearchQuery = (args) => {
 					query['habilitado'] = true;
 					query['$or'] = [];
 					query['$or'].push({ 'formacionGrado.matriculacion.matriculaNumero': parseInt(nroMatricula || 0, 10), 'formacionGrado.profesion.codigo': parseInt(tipoProfesion || 0, 10) });
-					query['$or'].push({ 'formacionPosgrado.matriculacion.matriculaNumero': parseInt(nroMatricula || 0, 10), 'formacionPosgrado.profesion.codigo': parseInt(tipoProfesion || 0, 10) });
+					query['$or'].push({ 'formacionPosgrado.matriculacion.matriculaNumero': parseInt(nroMatricula || 0, 10), 'formacionPosgrado.especialidad.codigo': parseInt(tipoProfesion || 0, 10) });
 				}
 				break;
 			case 'https://seti.afip.gob.ar/padron-puc-constancia-internet/ConsultaConstanciaAction.do':
@@ -93,7 +93,7 @@ export = {
 						const tokenBuilder: any = tokenQueryBuilder(args.identifier, 'value', 'identifier', false);
 						// Verificamos si lo que ingresamos por parametro es un numero de matricula y profesion
 						if (tokenBuilder.system === 'andes.gob.ar/matriculaciones') {
-							let matriculaVigente;
+							let matriculaVigente = false;
 							const [nroMatricula, codigoProfesion] = tokenBuilder.value.split('@');
 							const formacionGrado = practitioners.map(p => p.formacionGrado?.filter(f => f.matriculacion && f.matriculacion[f.matriculacion.length - 1].matriculaNumero.toString() === nroMatricula));
 							const formacionPosgrado = practitioners.map(p => p.formacionPosgrado?.filter(f => f.matriculacion[f.matriculacion.length - 1].matriculaNumero.toString() === nroMatricula));
@@ -102,8 +102,10 @@ export = {
 								practitioners.forEach(pract => pract.formacionGrado.forEach(form => {
 									matriculaVigente = verificarVigencia(form, codigoProfesion, nroMatricula);
 								}));
-							} else if (formacionPosgrado?.flat().length) {
+							}
+							if (!matriculaVigente && formacionPosgrado?.flat().length) {
 								practitioners.forEach(pract => pract.formacionPosgrado.forEach(form => {
+									form.profesion = form.especialidad;
 									matriculaVigente = verificarVigencia(form, codigoProfesion, nroMatricula);
 								}));
 							}


### PR DESCRIPTION
Se quito la consulta query['formacionGrado.matriculacion.fin'] = { $gte: new Date() }; ya que la misma no estaba devolviendo el resultado como corresponde, y se recorre el arreglo practitioners para verificar si la matricula por la que consultamos esta vencida o vigente. En caso de estar vencida nos devuelve un array vacío. También se verifica si las matriculas de posgrado se encuentran vigentes o no. En caso de no estarlo devolverá un arreglo vacio. 